### PR TITLE
Change accent color to Nextcloud Blue

### DIFF
--- a/app/App_Resources/Android/values/colors.xml
+++ b/app/App_Resources/Android/values/colors.xml
@@ -2,6 +2,6 @@
 <resources>
     <color name="ns_primary">#F5F5F5</color>
 	<color name="ns_primaryDark">#757575</color>
-	<color name="ns_accent">#33B5E5</color>
+	<color name="ns_accent">#0082C9</color>
     <color name="ns_blue">#272734</color>
 </resources>


### PR DESCRIPTION
Like mentioned in https://github.com/linfaservice/cloudgallery/issues/19 i would like to change the accent color to match across all 3rd-party-apps.